### PR TITLE
Remove `.js` from the name of the generated files

### DIFF
--- a/bin/emblem2hbs.js
+++ b/bin/emblem2hbs.js
@@ -11,7 +11,7 @@ if (process.argv.length < 3) {
   console.log('USAGE: emblem2hbs filetoconvert.emblem')
 } else {
   emblemFile = process.argv[2];
-  hbsFile = emblemFile.substr(0, emblemFile.lastIndexOf('.')) + '.js.hbs';
+  hbsFile = emblemFile.substr(0, emblemFile.lastIndexOf('.')) + '.hbs';
   buf = fs.readFileSync(emblemFile, 'utf8');
   output = processor.process(buf);
   fs.writeFileSync(hbsFile, indentation.indent(output));


### PR DESCRIPTION
Ths standard extension for Handlebars/HTMLBars is `.hbs` and not `.js.hbs`.

Although the double extension can be useful in some contexts (such as Rails assets pipeline), I think it is a good thing to provide users of `emblem2hbs` with a more agnostic/generic output.