### PR TITLE
More flexible USAGE methods

### DIFF
--- a/bin/emblem2hbs.js
+++ b/bin/emblem2hbs.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
 
 if (process.argv.length < 3) {
   if (process.stdin.isTTY) {
-    console.log('USAGE: emblem2hbs filetoconvert.emblem or in piped format `pbcopy | emblem2hbs | pbpaste`');
+    console.log('USAGE: `emblem2hbs filetoconvert.emblem [destinationFilename]` or in piped format `pbcopy | emblem2hbs | pbpaste`');
   }
   else {
     processFromPipe();

--- a/bin/emblem2hbs.js
+++ b/bin/emblem2hbs.js
@@ -9,14 +9,13 @@ var fs = require('fs'),
 if (process.argv.length < 3) {
   if (process.stdin.isTTY) {
     console.log('USAGE: emblem2hbs filetoconvert.emblem or in piped format `pbcopy | emblem2hbs | pbpaste`');
-    return;
   }
   else {
     processFromPipe();
   }
 } else {
   emblemFile = process.argv[2];
-  hbsFile = emblemFile.substr(0, emblemFile.lastIndexOf('.')) + '.hbs';
+  hbsFile = process.argv[3] ? process.argv[3] : emblemFile.substr(0, emblemFile.lastIndexOf('.')) + '.hbs';
   buf = fs.readFileSync(emblemFile, 'utf8');
   output = require('emblem').default.compile(buf);
   fs.writeFileSync(hbsFile, indentation.indent(output));


### PR DESCRIPTION
Allows for input from stdin to be used like so:

`pbpaste | emblem2hbs | cat`

```
<div class="head">
     <p>derp</p>
</div>
```

As well as specifying the destination filename like so in the traditional usage:

`emblem2hbs greatfile.emblem /bin/greatfile.hbs`